### PR TITLE
Use the JUnit version 5 APIs

### DIFF
--- a/src/test/java/eu/dnetlib/iis/core/examples/hadoopstreaming/WorkflowTest.java
+++ b/src/test/java/eu/dnetlib/iis/core/examples/hadoopstreaming/WorkflowTest.java
@@ -2,8 +2,7 @@ package eu.dnetlib.iis.core.examples.hadoopstreaming;
 
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
 
 import eu.dnetlib.iis.common.AbstractOozieWorkflowTestCase;
 import eu.dnetlib.iis.common.IntegrationTest;
@@ -19,7 +18,7 @@ import eu.dnetlib.iis.core.examples.schemas.documenttext.DocumentText;
  * @author Mateusz Kobos
  *
  */
-@Category(IntegrationTest.class)
+@IntegrationTest
 public class WorkflowTest extends AbstractOozieWorkflowTestCase {
 
 	@Test

--- a/src/test/java/eu/dnetlib/iis/core/examples/java/WorkflowTest.java
+++ b/src/test/java/eu/dnetlib/iis/core/examples/java/WorkflowTest.java
@@ -4,8 +4,7 @@ import java.io.File;
 import java.util.List;
 
 import org.apache.oozie.client.WorkflowJob;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
 
 import eu.dnetlib.iis.common.AbstractOozieWorkflowTestCase;
 import eu.dnetlib.iis.common.IntegrationTest;
@@ -23,7 +22,7 @@ import eu.dnetlib.iis.core.examples.schemas.documentandauthor.personwithdocument
  * @author Mateusz Kobos
  *
  */
-@Category(IntegrationTest.class)
+@IntegrationTest
 public class WorkflowTest extends AbstractOozieWorkflowTestCase {
 
 	@Test 

--- a/src/test/java/eu/dnetlib/iis/core/examples/javamapreduce/WorkflowTest.java
+++ b/src/test/java/eu/dnetlib/iis/core/examples/javamapreduce/WorkflowTest.java
@@ -3,8 +3,7 @@ package eu.dnetlib.iis.core.examples.javamapreduce;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
 
 import eu.dnetlib.iis.common.AbstractOozieWorkflowTestCase;
 import eu.dnetlib.iis.common.IntegrationTest;
@@ -21,7 +20,7 @@ import eu.dnetlib.iis.core.examples.schemas.documentandauthor.personwithdocument
  * @author Mateusz Kobos
  *
  */
-@Category(IntegrationTest.class)
+@IntegrationTest
 public class WorkflowTest extends AbstractOozieWorkflowTestCase {
 
 	@Test

--- a/src/test/java/eu/dnetlib/iis/core/examples/pig/WorkflowTest.java
+++ b/src/test/java/eu/dnetlib/iis/core/examples/pig/WorkflowTest.java
@@ -5,8 +5,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
 
 import eu.dnetlib.iis.common.AbstractOozieWorkflowTestCase;
 import eu.dnetlib.iis.common.IntegrationTest;
@@ -26,7 +25,7 @@ import eu.dnetlib.iis.core.examples.schemas.documentandauthor.personwithdocument
  * @author Dominika Tkaczyk
  *
  */
-@Category(IntegrationTest.class)
+@IntegrationTest
 public class WorkflowTest extends AbstractOozieWorkflowTestCase {
 
 	@Test

--- a/src/test/java/eu/dnetlib/iis/core/examples/pig/testing_with_json/removebelowthreshold/minioozie/WorkflowTest.java
+++ b/src/test/java/eu/dnetlib/iis/core/examples/pig/testing_with_json/removebelowthreshold/minioozie/WorkflowTest.java
@@ -1,7 +1,6 @@
 package eu.dnetlib.iis.core.examples.pig.testing_with_json.removebelowthreshold.minioozie;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
 
 import eu.dnetlib.iis.common.AbstractOozieWorkflowTestCase;
 import eu.dnetlib.iis.common.IntegrationTest;
@@ -9,7 +8,7 @@ import eu.dnetlib.iis.common.IntegrationTest;
 /**
  * @author Michal Oniszczuk (m.oniszczuk@icm.edu.pl)
  */
-@Category(IntegrationTest.class)
+@IntegrationTest
 public class WorkflowTest extends AbstractOozieWorkflowTestCase {
 
     @Test

--- a/src/test/java/eu/dnetlib/iis/core/examples/spark/rdd/FileWordCounterWorkflowTest.java
+++ b/src/test/java/eu/dnetlib/iis/core/examples/spark/rdd/FileWordCounterWorkflowTest.java
@@ -5,17 +5,16 @@ import eu.dnetlib.iis.common.IntegrationTest;
 import eu.dnetlib.iis.common.OozieWorkflowTestConfiguration;
 import eu.dnetlib.iis.common.WorkflowTestResult;
 import org.apache.commons.io.FileUtils;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Łukasz Dumiszewski
  */
-@Category(IntegrationTest.class)
+@IntegrationTest
 public class FileWordCounterWorkflowTest extends AbstractOozieWorkflowTestCase {
 
     @Test

--- a/src/test/java/eu/dnetlib/iis/core/examples/spark/rdd/PersonIdExtractorWorkflowTest.java
+++ b/src/test/java/eu/dnetlib/iis/core/examples/spark/rdd/PersonIdExtractorWorkflowTest.java
@@ -4,7 +4,7 @@ import eu.dnetlib.iis.common.AbstractOozieWorkflowTestCase;
 import eu.dnetlib.iis.common.OozieWorkflowTestConfiguration;
 import eu.dnetlib.iis.common.TestsIOUtils;
 import eu.dnetlib.iis.common.WorkflowTestResult;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.FileInputStream;
 

--- a/src/test/java/eu/dnetlib/iis/core/examples/spark/rdd/SparkAvroClonerTest.java
+++ b/src/test/java/eu/dnetlib/iis/core/examples/spark/rdd/SparkAvroClonerTest.java
@@ -5,9 +5,9 @@ import eu.dnetlib.iis.core.examples.StandardDataStoreExamples;
 import eu.dnetlib.iis.core.examples.schemas.documentandauthor.Person;
 import org.apache.avro.util.Utf8;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import pl.edu.icm.sparkutils.test.SparkJob;
 import pl.edu.icm.sparkutils.test.SparkJobBuilder;
 import pl.edu.icm.sparkutils.test.SparkJobExecutor;
@@ -17,7 +17,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Łukasz Dumiszewski
@@ -28,12 +28,12 @@ public class SparkAvroClonerTest {
 
     private File workingDir;
 
-    @Before
+    @BeforeEach
     public void before() throws IOException {
         workingDir = Files.createTempDirectory(SparkAvroClonerTest.class.getSimpleName()).toFile();
     }
 
-    @After
+    @AfterEach
     public void after() throws IOException {
         FileUtils.deleteDirectory(workingDir);
     }

--- a/src/test/java/eu/dnetlib/iis/core/examples/spark/rdd/SparkAvroClonerWorkflowTest.java
+++ b/src/test/java/eu/dnetlib/iis/core/examples/spark/rdd/SparkAvroClonerWorkflowTest.java
@@ -6,17 +6,16 @@ import eu.dnetlib.iis.common.OozieWorkflowTestConfiguration;
 import eu.dnetlib.iis.common.WorkflowTestResult;
 import eu.dnetlib.iis.core.examples.schemas.documentandauthor.Person;
 import org.apache.avro.util.Utf8;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Łukasz Dumiszewski
  */
-@Category(IntegrationTest.class)
+@IntegrationTest
 public class SparkAvroClonerWorkflowTest extends AbstractOozieWorkflowTestCase {
 
     @Test

--- a/src/test/java/eu/dnetlib/iis/core/examples/spark/rdd/SparkPipeClonerWorkflowTest.java
+++ b/src/test/java/eu/dnetlib/iis/core/examples/spark/rdd/SparkPipeClonerWorkflowTest.java
@@ -2,13 +2,12 @@ package eu.dnetlib.iis.core.examples.spark.rdd;
 
 import eu.dnetlib.iis.common.AbstractOozieWorkflowTestCase;
 import eu.dnetlib.iis.common.IntegrationTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author madryk
  */
-@Category(IntegrationTest.class)
+@IntegrationTest
 public class SparkPipeClonerWorkflowTest extends AbstractOozieWorkflowTestCase {
 
     @Test

--- a/src/test/java/eu/dnetlib/iis/core/examples/spark/rdd/SparkPipeExecutorTest.java
+++ b/src/test/java/eu/dnetlib/iis/core/examples/spark/rdd/SparkPipeExecutorTest.java
@@ -10,27 +10,27 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.PairFunction;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Matchers;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import scala.Option;
 import scala.Tuple2;
 
 import java.io.File;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
 /**
  * @author madryk
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SparkPipeExecutorTest {
 
     private SparkPipeExecutor pipeExecutor = new SparkPipeExecutor();
@@ -74,7 +74,7 @@ public class SparkPipeExecutorTest {
     @Captor
     private ArgumentCaptor<PairFunction<Document, AvroKey<GenericRecord>, NullWritable>> avroDocumentToAvroKeyValueFunctionArg;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         SparkEnv sparkEnv = mock(SparkEnv.class);
         when(sparkEnv.driverTmpDir()).thenReturn(Option.apply("/some/spark/dir"));

--- a/src/test/java/eu/dnetlib/iis/core/examples/spark/rdd/SparkPipeMapReduceTest.java
+++ b/src/test/java/eu/dnetlib/iis/core/examples/spark/rdd/SparkPipeMapReduceTest.java
@@ -6,9 +6,9 @@ import eu.dnetlib.iis.core.examples.StandardDataStoreExamples;
 import eu.dnetlib.iis.core.examples.schemas.WordCount;
 import eu.dnetlib.iis.core.examples.schemas.documentandauthor.Person;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import pl.edu.icm.sparkutils.test.SparkJob;
 import pl.edu.icm.sparkutils.test.SparkJobBuilder;
 import pl.edu.icm.sparkutils.test.SparkJobExecutor;
@@ -21,7 +21,7 @@ import java.util.List;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author madryk
@@ -34,14 +34,14 @@ public class SparkPipeMapReduceTest {
     private String inputDirPath;
     private String outputDirPath;
 
-    @Before
+    @BeforeEach
     public void before() throws IOException {
         workingDir = Files.createTempDirectory(SparkPipeMapReduceTest.class.getSimpleName()).toFile();
         inputDirPath = workingDir + "/input";
         outputDirPath = workingDir + "/output";
     }
 
-    @After
+    @AfterEach
     public void after() throws IOException {
         FileUtils.deleteDirectory(workingDir);
     }

--- a/src/test/java/eu/dnetlib/iis/core/examples/spark/sql/FileWordCounterWorkflowTest.java
+++ b/src/test/java/eu/dnetlib/iis/core/examples/spark/sql/FileWordCounterWorkflowTest.java
@@ -8,24 +8,23 @@ import eu.dnetlib.iis.common.spark.SparkSessionFactory;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Category(IntegrationTest.class)
+@IntegrationTest
 public class FileWordCounterWorkflowTest extends AbstractOozieWorkflowTestCase {
 
     private static SparkSession spark;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         SparkConf conf = new SparkConf();
         conf.setMaster("local");
@@ -34,7 +33,7 @@ public class FileWordCounterWorkflowTest extends AbstractOozieWorkflowTestCase {
         spark = SparkSessionFactory.withConfAndKryo(conf);
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         spark.stop();
     }

--- a/src/test/java/eu/dnetlib/iis/core/examples/spark/sql/PersonIdExtractorWorkflowTest.java
+++ b/src/test/java/eu/dnetlib/iis/core/examples/spark/sql/PersonIdExtractorWorkflowTest.java
@@ -4,13 +4,14 @@ import eu.dnetlib.iis.common.AbstractOozieWorkflowTestCase;
 import eu.dnetlib.iis.common.OozieWorkflowTestConfiguration;
 import eu.dnetlib.iis.common.TestsIOUtils;
 import eu.dnetlib.iis.common.WorkflowTestResult;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author madryk
@@ -32,7 +33,7 @@ public class PersonIdExtractorWorkflowTest extends AbstractOozieWorkflowTestCase
                 .filter(x -> x.getFileName().toString().startsWith("part-00000"))
                 .collect(Collectors.toList());
 
-        Assert.assertEquals(1, files.size());
+        assertEquals(1, files.size());
         TestsIOUtils
                 .assertUtf8TextContentsEqual(
                         this.getClass().getResourceAsStream("/eu/dnetlib/iis/core/examples/simple_csv_data/person_id.csv"),

--- a/src/test/java/eu/dnetlib/iis/core/examples/spark/sql/SparkAvroClonerTest.java
+++ b/src/test/java/eu/dnetlib/iis/core/examples/spark/sql/SparkAvroClonerTest.java
@@ -5,9 +5,9 @@ import eu.dnetlib.iis.core.examples.StandardDataStoreExamples;
 import eu.dnetlib.iis.core.examples.schemas.documentandauthor.Person;
 import org.apache.avro.util.Utf8;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import pl.edu.icm.sparkutils.test.SparkJob;
 import pl.edu.icm.sparkutils.test.SparkJobBuilder;
 import pl.edu.icm.sparkutils.test.SparkJobExecutor;
@@ -17,7 +17,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Łukasz Dumiszewski
@@ -28,12 +28,12 @@ public class SparkAvroClonerTest {
 
     private File workingDir;
 
-    @Before
+    @BeforeEach
     public void before() throws IOException {
         workingDir = Files.createTempDirectory(SparkAvroClonerTest.class.getSimpleName()).toFile();
     }
 
-    @After
+    @AfterEach
     public void after() throws IOException {
         FileUtils.deleteDirectory(workingDir);
     }

--- a/src/test/java/eu/dnetlib/iis/core/examples/spark/sql/SparkAvroClonerWorkflowTest.java
+++ b/src/test/java/eu/dnetlib/iis/core/examples/spark/sql/SparkAvroClonerWorkflowTest.java
@@ -6,17 +6,16 @@ import eu.dnetlib.iis.common.OozieWorkflowTestConfiguration;
 import eu.dnetlib.iis.common.WorkflowTestResult;
 import eu.dnetlib.iis.core.examples.schemas.documentandauthor.Person;
 import org.apache.avro.util.Utf8;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Łukasz Dumiszewski
  */
-@Category(IntegrationTest.class)
+@IntegrationTest
 public class SparkAvroClonerWorkflowTest extends AbstractOozieWorkflowTestCase {
 
     @Test

--- a/src/test/java/eu/dnetlib/iis/core/examples/subworkflow/WorkflowTest.java
+++ b/src/test/java/eu/dnetlib/iis/core/examples/subworkflow/WorkflowTest.java
@@ -2,8 +2,7 @@ package eu.dnetlib.iis.core.examples.subworkflow;
 
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
 
 import eu.dnetlib.iis.common.AbstractOozieWorkflowTestCase;
 import eu.dnetlib.iis.common.IntegrationTest;
@@ -18,7 +17,7 @@ import eu.dnetlib.iis.core.examples.schemas.documentandauthor.Person;
  * @author Mateusz Kobos
  *
  */
-@Category(IntegrationTest.class)
+@IntegrationTest
 public class WorkflowTest extends AbstractOozieWorkflowTestCase {
 
 	@Test 


### PR DESCRIPTION
Fixes #8.

When iis was upgraded to use JUnit 5 iis-examples were
forgotten. Since they take their dependency versions from iis via
their parent pom tests stopped being executed at all.

Fix this by moving iis-examples to the JUnit 5 (jupiter) APIs.
The changes needed in this smaller project are a subset of those in
https://github.com/openaire/iis/pull/1164
- use equivalent Junit 5 classes from org.junit.jupiter.api
  instead of Junit 4 classes from org.junit
- use `@IntegrationTest` annotation (from iis-common) instead of
  `@Category`
- use `@ExtendWith(MockitoExtension.class)` instead of `@RunWith(MockitoJUnitRunner.class)`