### PR TITLE
Add necessary repository information to pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,27 @@
     <artifactId>iis-wf-core-examples</artifactId>
     <packaging>jar</packaging>
 
+    <repositories>
+        <repository>
+            <id>iis-snapshots</id>
+            <url>https://maven.ceon.pl/artifactory/iis-snapshots/</url>
+	    <releases>
+              <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+	<pluginRepository>
+            <id>iis-snapshots</id>
+            <name>iis snapshots plugin repository</name>
+            <url>https://maven.ceon.pl/artifactory/iis-snapshots</url>
+	    <releases>
+	      <enabled>false</enabled>
+	    </releases>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>eu.dnetlib.iis</groupId>


### PR DESCRIPTION
To be able to build and test this project without needing to first
build and install iis locally add repository information to pom.

- iis-snapshots repository to get parent poms - note that it is
specifically https://maven.ceon.pl/artifactory/iis-snapshots/ and not
https://maven.ceon.pl/artifactory/repo because the latter is
configured to strip repository information from downloaded poms.
- iis-snapshots plugin repository to get the iis-build-properties
Maven plugin